### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/HEIGE-PCloud/Notion-Hugo/security/code-scanning/1](https://github.com/HEIGE-PCloud/Notion-Hugo/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the job only installs dependencies and runs a typecheck, it does not require any write permissions. The minimal required permission is `contents: read`. This block should be added at the root level of the workflow (just after the `name` field and before `on:`), so it applies to all jobs in the workflow. No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
